### PR TITLE
Changed cdniets to extend current time instead of extending the previ…

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -545,8 +545,8 @@
             Time Setting (cdniets) claim provides a means for setting the value
             of the Expiry Time (exp) claim when generating a subsequent signed JWT
             in a Signed Token Chain. Its type is a JSON integer
-            denotes the number of seconds to be added to the Expiry Time (exp) claim
-            of the previous signed JWT that gives the value of the Expiry Time (exp) claim of the next signed JWT.
+            denotes the number of seconds to be added to the time at which the JWT is validated
+            that gives the value of the Expiry Time (exp) claim of the next signed JWT.
             The CDNI Expiration Time Setting (cdniets) SHOULD NOT be used when not using a Signed Token Chain.</t>
         </section>
         <section anchor="cdnistt_claim" title="CDNI Signed Token Transport (cdnistt) claim">


### PR DESCRIPTION
…ous token.

This prevents a malefactor from continuously revalidating the same token to create
an arbitrarily long expiration on a token.