### PR TITLE
Make cdniets mandatory when using the Signed Token Chain.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -547,7 +547,8 @@
             in a Signed Token Chain. Its type is a JSON integer
             denotes the number of seconds to be added to the Expiry Time (exp) claim
             of the previous signed JWT that gives the value of the Expiry Time (exp) claim of the next signed JWT.
-            The CDNI Expiration Time Setting (cdniets) SHOULD NOT be used when not using a Signed Token Chain.</t>
+            The CDNI Expiration Time Setting (cdniets) SHOULD NOT be used when not using a Signed Token Chain
+            and MUST be preset when using a Signed Token Chain.</t>
         </section>
         <section anchor="cdnistt_claim" title="CDNI Signed Token Transport (cdnistt) claim">
           <t>CDNI Signed Token Transport (cdnistt) [optional] - The CDNI Signed Token Transport (cdnistt) claim


### PR DESCRIPTION
Signed Token Chain doesn't work or make sense without some
way to figure out how much time to add to renewals.