### PR TITLE
Changed sub claim to cdniuc and introduced new sub claim.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -1593,7 +1593,7 @@ http://*/folder/content-83112371/quality_*/segment????.mp4
 
         <figure><artwork><![CDATA[
 {
-  "sub": "uri:http://cdni.example/foo/bar/baz"
+  "cdniuc": "uri:http://cdni.example/foo/bar/baz"
 }
 ]]></artwork></figure>
 
@@ -1603,9 +1603,9 @@ http://*/folder/content-83112371/quality_*/segment????.mp4
 
         <figure><artwork><![CDATA[
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
-dZRkRPV2tsZHVlYUltZjAifQ.eyJzdWIiOiJ1cmk6aHR0cDovL2NkbmkuZXhhbXBsZ
-S9mb28vYmFyL2JheiJ9.LTizGd7zCb17Qp_80ClGApLCieRIq3dCjcRckNfLqiJ4BT
-GSfVXoDtm0Z6L5Jx4EmwM1w-WkznNajUy11iMAcA
+dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pdWMiOiJ1cmk6aHR0cDovL2NkbmkuZXhhb
+XBsZS9mb28vYmFyL2JheiJ9.qiaXdZkCXKxSgSOFFDZ7lG82zCD64pCRrO3eJRWYO7
+QfmaJ0XOL4XOi9Q0VBWKKWIkrzVdRNaOPctauxFzNbAg
 ]]></artwork></figure>
       </section>
 
@@ -1623,8 +1623,8 @@ GSfVXoDtm0Z6L5Jx4EmwM1w-WkznNajUy11iMAcA
 
         <figure><artwork><![CDATA[
 eyJhbGciOiJkaXIiLCJraWQiOiJmLVdianhCQzNkUHVJM2QyNGtQMmhmdm9zN1F6Nj
-g4VVRpNmFCMGhOOTk4IiwiZW5jIjoiQTEyOEdDTSJ9..oGLsnF8fLlFcUXK0.KFfBB
-H_FPYFu-RBFBR3rhQ.6_MVaa4t7JiVX2IgUkZ3jA
+g4VVRpNmFCMGhOOTk4IiwiZW5jIjoiQTEyOEdDTSJ9..eXvtEV54CyFJf8WL.-5I0k
+_vHcrR_QR7djONUaQ.gIt4W4hwR_1k6Z2IDVny8w
 ]]></artwork></figure>
 
         <t>
@@ -1634,15 +1634,15 @@ H_FPYFu-RBFBR3rhQ.6_MVaa4t7JiVX2IgUkZ3jA
         <figure><artwork><![CDATA[
 {
   "aud": "eyJhbGciOiJkaXIiLCJraWQiOiJmLVdianhCQzNkUHVJM2QyNGtQMmhm
-dm9zN1F6Njg4VVRpNmFCMGhOOTk4IiwiZW5jIjoiQTEyOEdDTSJ9..oGLsnF8fLlFc
-UXK0.KFfBBH_FPYFu-RBFBR3rhQ.6_MVaa4t7JiVX2IgUkZ3jA",
+dm9zN1F6Njg4VVRpNmFCMGhOOTk4IiwiZW5jIjoiQTEyOEdDTSJ9..eXvtEV54CyFJ
+f8WL.-5I0k_vHcrR_QR7djONUaQ.gIt4W4hwR_1k6Z2IDVny8w",
   "cdniv": 1,
   "exp": 1474243500,
   "iat": 1474243200,
   "iss": "uCDN Inc",
   "jti": "5DAafLhZAfhsbe",
   "nbf": 1474243200,
-  "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.png"
+  "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.png"
 }
 ]]></artwork></figure>
 
@@ -1654,13 +1654,13 @@ UXK0.KFfBBH_FPYFu-RBFBR3rhQ.6_MVaa4t7JiVX2IgUkZ3jA",
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
 dZRkRPV2tsZHVlYUltZjAifQ.eyJhdWQiOiJleUpoYkdjaU9pSmthWElpTENKcmFXU
 WlPaUptTFZkaWFuaENRek5rVUhWSk0yUXlOR3RRTW1obWRtOXpOMUY2TmpnNFZWUnB
-ObUZDTUdoT09UazRJaXdpWlc1aklqb2lRVEV5T0VkRFRTSjkuLm9HTHNuRjhmTGxGY
-1VYSzAuS0ZmQkJIX0ZQWUZ1LVJCRkJSM3JoUS42X01WYWE0dDdKaVZYMklnVWtaM2p
-BIiwiY2RuaXYiOjEsImV4cCI6MTQ3NDI0MzUwMCwiaWF0IjoxNDc0MjQzMjAwLCJpc
+ObUZDTUdoT09UazRJaXdpWlc1aklqb2lRVEV5T0VkRFRTSjkuLmVYdnRFVjU0Q3lGS
+mY4V0wuLTVJMGtfdkhjclJfUVI3ZGpPTlVhUS5nSXQ0VzRod1JfMWs2WjJJRFZueTh
+3IiwiY2RuaXYiOjEsImV4cCI6MTQ3NDI0MzUwMCwiaWF0IjoxNDc0MjQzMjAwLCJpc
 3MiOiJ1Q0ROIEluYyIsImp0aSI6IjVEQWFmTGhaQWZoc2JlIiwibmJmIjoxNDc0MjQ
-zMjAwLCJzdWIiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGFtcGxlL2Zvby9iY
-XIvYmF6L1swLTldezN9XFwucG5nIn0.r2FiSdfnGRw_RC2roGwh4LEYlfsWGF972-M
-f3He_LhGr2_3eRXP0jP_OFPj5NEtTZFY4PX_iD7vPD12_HPDJCQ
+zMjAwLCJjZG5pdWMiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGFtcGxlL2Zvb
+y9iYXIvYmF6L1swLTldezN9XFwucG5nIn0.NmLT5Cjvhg0isAtw3NiMjYttJEwrWCS
+sdsA7avjQVxRcIQtQzTn6xKZ1NYg1l21jtz2FXE6Cmf6JaHoGVOaacw
 ]]></artwork></figure>
 
       </section>
@@ -1679,7 +1679,7 @@ f3He_LhGr2_3eRXP0jP_OFPj5NEtTZFY4PX_iD7vPD12_HPDJCQ
   "cdniets": 30,
   "cdnistt": 1,
   "exp": 1474243500,
-  "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
+  "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
 }
 ]]></artwork></figure>
 
@@ -1690,9 +1690,9 @@ f3He_LhGr2_3eRXP0jP_OFPj5NEtTZFY4PX_iD7vPD12_HPDJCQ
         <figure><artwork><![CDATA[
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
 dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiZXhwI
-joxNDc0MjQzNTAwLCJzdWIiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGFtcGx
-lL2Zvby9iYXIvYmF6L1swLTldezN9XFwudHMifQ.VYF7Eqk1WhRWdvDVUx5mXDJaS-
-r6jbjgiYuwIEAYmbLWsF2dUDohrV70sz7TC09n-oNf_ws4eeH_A6AnvF4FTQ
+joxNDc0MjQzNTAwLCJjZG5pdWMiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGF
+tcGxlL2Zvby9iYXIvYmF6L1swLTldezN9XFwudHMifQ.zNFrgyDhDhg_eu8D9upedO
+0aHGas_CzzAydEUgARJG_CJd51t8OLisv87KRkPYNYroW3yMYx_hEmSjCdfz-_hA
 ]]></artwork></figure>
 
         <t>
@@ -1711,7 +1711,7 @@ r6jbjgiYuwIEAYmbLWsF2dUDohrV70sz7TC09n-oNf_ws4eeH_A6AnvF4FTQ
   "cdniets": 30,
   "cdnistt": 1,
   "exp": 1474243530,
-  "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
+  "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
 }
 ]]></artwork></figure>
 
@@ -1722,9 +1722,9 @@ r6jbjgiYuwIEAYmbLWsF2dUDohrV70sz7TC09n-oNf_ws4eeH_A6AnvF4FTQ
         <figure><artwork><![CDATA[
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
 dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiZXhwI
-joxNDc0MjQzNTMwLCJzdWIiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGFtcGx
-lL2Zvby9iYXIvYmF6L1swLTldezN9XFwudHMifQ.zzXhYg6b7_8MylW-RS97qZv3hQ
-QlYg-TxhC-wigdB4moxlFEjndDvv0EDxl42faQaE39BCHZq7H-DXVpBrhxTw
+joxNDc0MjQzNTMwLCJjZG5pdWMiOiJ1cmktcmVnZXg6aHR0cDovL2NkbmlcXC5leGF
+tcGxlL2Zvby9iYXIvYmF6L1swLTldezN9XFwudHMifQ.kVEd5s-HZX-a6V7qBq5uJO
+qo1O__4WvYXg5APKKgvEd3z5Ca721GANCTnRCF8a0AZJqO0jBagb_ZKLA81q3yWw
 ]]></artwork></figure>
       </section>
     </section>

--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -1368,6 +1368,16 @@ http://*/folder/content-83112371/quality_*/segment????.mp4
 	    </list>
 	  </t>
 	  <?rfc subcompact="no"?>
+	  <t>
+	    <?rfc subcompact="yes"?>
+	    <list style="symbols">
+	      <t>Claim Name: <spanx style="verb">cdniuc</spanx></t>
+	      <t>Claim Description: CDNI URI Container</t>
+	      <t>Change Controller: IESG</t>
+	      <t>Specification Document(s): <xref target="cdniuc_claim"/> of [[ this specification ]]</t>
+	    </list>
+	  </t>
+	  <?rfc subcompact="no"?>
 
 	</section>
       </section>

--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -430,16 +430,19 @@
             contain an Issuer claim, an Issuer claim MAY be added to
             a signed JWT generated for CDNI redirection.</t> 
         </section>
-        <section anchor="sub_claim" title="URI Container (sub) claim">
-            <t>URI Container (sub) [mandatory] - The semantics in <xref target="RFC7519"/> Section 4.1.2 MUST be followed.
-            Container for holding the URI representation before a URI Signing Package is
-            added. This representation can take one of several forms detailed in
-            <xref target="uri_container_forms"/>. If the URI pattern/regex in the signed
-            JWT does not match the URI of the content request,  the CDN validating the
-            signed JWT MUST reject the request. When comparing the URI the percent encoded
-            form as defined in <xref target="RFC3986"/> Section 2.1 MUST be used. When
-            redirecting a URI, the CDN generating the new signed JWT MAY change the URI
-            Container to comport with the URI being used in the redirection.</t>
+        <section anchor="sub_claim" title="Subject (sub) claim">
+            <t>Subject (sub) [optional] - The semantics in [RFC7519] Section 4.1.2 MUST be followed.
+            If this claim is used, it MUST be a JSON Web Encryption (<xref target="RFC7516">JWE</xref>)
+            Object in compact serialization form, because it contains
+            personally identifiable information. This claim contains
+            information about the subject (for example, a user or an agent)
+            that MAY be used to validate the signed JWT.
+            If the received signed JWT contains a Subject claim, then any
+            JWT subsequently generated for CDNI redirection MUST also
+            contain a Subject claim, and the Subject value MUST be the same
+            as in the received signed JWT. A signed JWT generated for CDNI
+            redirection MUST NOT add a Subject claim if no Subject claim
+            existed in the received signed JWT.</t>
         </section>
         <section anchor="aud_claim" title="Client IP (aud) claim">
             <t>Client IP (aud) [optional] - The semantics in <xref target="RFC7519"/> Section 4.1.3 MUST be followed.
@@ -540,6 +543,17 @@
             to be "1". For future versions this claim will be mandatory. Implementations MUST reject
             signed JWTs with unsupported CDNI Claim Set versions.</t>
         </section>
+        <section anchor="cdniuc_claim" title="CDNI URI Container (cdniuc) claim">
+            <t>URI Container (cdniuc) [mandatory] -
+            Container for holding the URI representation before a URI Signing Package is
+            added. This representation can take one of several forms detailed in
+            <xref target="uri_container_forms"/>. If the URI pattern/regex in the signed
+            JWT does not match the URI of the content request,  the CDN validating the
+            signed JWT MUST reject the request. When comparing the URI, the percent encoded
+            form as defined in <xref target="RFC3986"/> Section 2.1 MUST be used. When
+            redirecting a URI, the CDN generating the new signed JWT MAY change the URI
+            Container to comport with the URI being used in the redirection.</t>
+        </section>
         <section anchor="cdniets_claim" title="CDNI Expiration Time Setting (cdniets) claim">
             <t>CDNI Expiration Time Setting (cdniets) [optional] - The CDNI Expiration
             Time Setting (cdniets) claim provides a means for setting the value
@@ -558,7 +572,7 @@
           Additional values for this claim can be defined in <xref target="sec.IANA.cdnistt"/>.</t>
         </section>
         <section anchor="uri_container_forms" title="URI Container Forms">
-          <t>The URI Container (sub) claim takes one of the following forms. More forms may be added in the future to extend the capabilities.</t>
+          <t>The URI Container (cdniuc) claim takes one of the following forms. More forms may be added in the future to extend the capabilities.</t>
 
           <section anchor="uri_container_forms_uri" title="URI Simple Container (uri:)">
               <t>When prefixed with 'uri:', the string following 'uri:' is the URI that MUST be matched with a simple string match to the requested URI.</t>
@@ -681,7 +695,7 @@ http://*/folder/content-83112371/quality_*/segment????.mp4
         seeking within the content and for switching to a different quality level),
         the Signed Token Chain uses the URI Pattern Container and/or the
         URI Regular Expression Container scoping mechanisms in the URI Container
-        (sub) claim to allow the Signed Token Chain to be valid for more than one URL.</t>
+        (cdniuc) claim to allow the Signed Token Chain to be valid for more than one URL.</t>
 
         <t>In order for this chaining of signed JWTs to work, it is necessary for
         a UA to extract the signed JWT from the HTTP 2xx Successful message of an
@@ -1570,7 +1584,7 @@ http://*/folder/content-83112371/quality_*/segment????.mp4
      <section title="Simple Example" anchor="simple_example">
         <t>
           This example is the simplest possible example containing
-          the only required field (sub).
+          the only required field (cdniuc).
         </t>
 
         <t>

--- a/example/index.js
+++ b/example/index.js
@@ -38,7 +38,7 @@ function loadKey(kname) {
 
 var samples = {
   "simple": {
-    "sub": "uri:http://cdni.example/foo/bar/baz"
+    "cdniuc": "uri:http://cdni.example/foo/bar/baz"
   },
   "complex": {
     "aud": "[2001:db8::1/32]",
@@ -48,19 +48,19 @@ var samples = {
     "iss": "uCDN Inc",
     "jti": "5DAafLhZAfhsbe",
     "nbf": 1474243200,
-    "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.png"
+    "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.png"
   },
   "chained-1": {
     "cdniets": 30,
     "cdnistt": 1,
     "exp": 1474243500,
-    "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
+    "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
   },
   "chained-2": {
     "cdniets": 30,
     "cdnistt": 1,
     "exp": 1474243530,
-    "sub": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
+    "cdniuc": "uri-regex:http://cdni\\.example/foo/bar/baz/[0-9]{3}\\.ts"
   }
 };
 


### PR DESCRIPTION
This fixes a fairly fundamental incompatibility between the JWT
specification and the existing sub claim. Subject claims that contain
colons must be URIs, and there is no reasonable way to make the
URI container format match.

This helpfully frees up the sub claim to be used for it's intended
purpose: identifying the user. Although user identification should
generally be avoided, this provides a standard-compliant way of
communicating the information and requires that it be encrypted
for privacy. Absent this, implementations are likely to simply put
the user information in the clear somewhere if they need it. This
encourages privacy.