### PR TITLE
Added CDNI Signed Token Depth claim.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -585,6 +585,26 @@
           Values for this claim can be defined in <xref target="sec.IANA.cdnistt"/>. If using
           this claim you MUST also specify a CDNI Expiration Time Setting (cdniets) as noted above.</t>
         </section>
+        <section anchor="cdnistd_claim" title="CDNI Signed Token Depth (cdnistd) claim">
+          <t>CDNI Signed Token Depth (cdnistd) [optional] - The CDNI Signed Token Depth (cdnistd) claim is used to
+          associate a subsequent signed JWT generated as the result of a CDNI Signed Token Transport claim
+          with a specific URI subset. Its type is a JSON integer. Signed JWTs MUST NOT use a negative
+          value for the CDNI Signed Token Depth claim.</t>
+          <t>If the transport used for Signed Token Transport allows the CDN to associate the path component of a
+          URI with tokens, the CDNI Signed Token Depth value is the number of path segments that should be
+          considered significant for this association. A CDNI Signed Token Depth of zero means that the
+          client SHOULD be directed to return the token with requests for any path. If the CDNI Signed
+          Token Depth is greater than zero, then the client SHOULD be directed to return the token for
+          future requests wherein the first CDNI Signed Token Depth segments of the path match the first
+          CDNI Signed Token Depth segments of the signed URI path. This matching MUST use the URI with the
+          token removed, as specified in <xref target="uri_container_forms"/>.</t>
+          <t>If the URI path to match contains fewer segments than the CDNI Signed Token Depth claim, a signed JWT
+          MUST NOT be generated for the purposes of Signed Token Renewal. If the CDNI Signed Token Depth
+          claim is omitted, it means the same thing as if its value were zero. If the received signed JWT
+          contains a CDNI Signed Token Depth claim, then any JWT subsequently generated for CDNI
+          redirection or Signed Token Transport MUST also contain a CDNI Signed Token Depth claim, and the
+          value MUST be the same as in the received signed JWT.</t>
+        </section>
         <section anchor="uri_container_forms" title="URI Container Forms">
           <t>The URI Container (cdniuc) claim takes one of the following forms. More forms may be added in the future to extend the capabilities.</t>
           <t>Before utilizing a URI with this container, the following steps MUST be performed:
@@ -1328,82 +1348,82 @@
 
       <section anchor="ClaimsReg" title="JSON Web Token Claims Registration">
 
-	<t>
-	  This specification registers the following Claims
-	  in the IANA "JSON Web Token Claims" registry
-	  <xref target="IANA.JWT.Claims"/>
-	  established by <xref target="RFC7519"/>.
-	</t>
+        <t>
+          This specification registers the following Claims
+          in the IANA "JSON Web Token Claims" registry
+          <xref target="IANA.JWT.Claims"/>
+          established by <xref target="RFC7519"/>.
+        </t>
 
-	<section anchor='ClaimsContents' title='Registry Contents'>
+        <section anchor='ClaimsContents' title='Registry Contents'>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdniv</spanx></t>
-	      <t>Claim Description: CDNI Claim Set Version</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdniv_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdniv</spanx></t>
+              <t>Claim Description: CDNI Claim Set Version</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdniv_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdnicrit</spanx></t>
-	      <t>Claim Description: CDNI Critical Claims Set</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdnicrit_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdnicrit</spanx></t>
+              <t>Claim Description: CDNI Critical Claims Set</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdnicrit_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdniip</spanx></t>
-	      <t>Claim Description: CDNI IP Address</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdniip_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdniip</spanx></t>
+              <t>Claim Description: CDNI IP Address</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdniip_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdniuc</spanx></t>
-	      <t>Claim Description: CDNI URI Container</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdniuc_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdniuc</spanx></t>
+              <t>Claim Description: CDNI URI Container</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdniuc_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdniets</spanx></t>
-	      <t>Claim Description: CDNI Expiration Time Setting for Signed Token Renewal</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdniets_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdniets</spanx></t>
+              <t>Claim Description: CDNI Expiration Time Setting for Signed Token Renewal</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdniets_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	  <t>
-	    <?rfc subcompact="yes"?>
-	    <list style="symbols">
-	      <t>Claim Name: <spanx style="verb">cdnistt</spanx></t>
-	      <t>Claim Description: CDNI Signed Token Transport Method for Signed Token Renewal</t>
-	      <t>Change Controller: IESG</t>
-	      <t>Specification Document(s): <xref target="cdnistt_claim"/> of [[ this specification ]]</t>
-	    </list>
-	  </t>
-	  <?rfc subcompact="no"?>
+          <t>
+            <?rfc subcompact="yes"?>
+            <list style="symbols">
+              <t>Claim Name: <spanx style="verb">cdnistt</spanx></t>
+              <t>Claim Description: CDNI Signed Token Transport Method for Signed Token Renewal</t>
+              <t>Change Controller: IESG</t>
+              <t>Specification Document(s): <xref target="cdnistt_claim"/> of [[ this specification ]]</t>
+            </list>
+          </t>
+          <?rfc subcompact="no"?>
 
-	</section>
+        </section>
       </section>
     </section>
 
@@ -1558,7 +1578,7 @@
           <author>
             <organization>IANA</organization>
           </author>
-	  <date/>
+          <date/>
         </front>
       </reference>
 
@@ -1570,7 +1590,7 @@
           <author>
             <organization>ISO</organization>
           </author>
-	  <date month="05" year="2014"/>
+          <date month="05" year="2014"/>
         </front>
         <seriesInfo name="ISO/IEC" value="23009-1:2014"/>
         <seriesInfo name="Edition" value="2"/>

--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -1763,7 +1763,7 @@ SWi9agE9vtuDsOzkbBGgd691XtjrjL-JO_g
         </t>
 
         <figure><artwork><![CDATA[
-
+{
   "cdniets": 30,
   "cdnistt": 1,
   "cdnistd": 2,

--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -1763,9 +1763,10 @@ SWi9agE9vtuDsOzkbBGgd691XtjrjL-JO_g
         </t>
 
         <figure><artwork><![CDATA[
-{
+
   "cdniets": 30,
   "cdnistt": 1,
+  "cdnistd": 2,
   "exp": 1474243500,
   "cdniuc": "regex:http://cdni\\.example/foo/bar/[0-9]{3}\\.ts"
 }
@@ -1777,10 +1778,11 @@ SWi9agE9vtuDsOzkbBGgd691XtjrjL-JO_g
 
         <figure><artwork><![CDATA[
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
-dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiZXhwI
-joxNDc0MjQzNTAwLCJjZG5pdWMiOiJyZWdleDpodHRwOi8vY2RuaVxcLmV4YW1wbGU
-vZm9vL2Jhci9bMC05XXszfVxcLnRzIn0.J3JFrn3XAS7AJ-Fx1RKA23DiYvI1T6UPo
-GbtAIBjIcV0at19ACAp7T3phz6_co1m3butnzxknJddz3svNQnkkQ
+dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiY2Rua
+XN0ZCI6MiwiZXhwIjoxNDc0MjQzNTAwLCJjZG5pdWMiOiJyZWdleDpodHRwOi8vY2R
+uaVxcLmV4YW1wbGUvZm9vL2Jhci9bMC05XXszfVxcLnRzIn0.sVMHF23EHdf0LWohl
+hsxDQkoG3UzxX6M57TwE3yNGY4rv1c2iDMNDinERwnNuOwc6ExhictbQIhIuus5pcY
+moQ
 ]]></artwork></figure>
 
         <t>
@@ -1798,6 +1800,7 @@ GbtAIBjIcV0at19ACAp7T3phz6_co1m3butnzxknJddz3svNQnkkQ
 {
   "cdniets": 30,
   "cdnistt": 1,
+  "cdnistd": 2,
   "exp": 1474243530,
   "cdniuc": "regex:http://cdni\\.example/foo/bar/[0-9]{3}\\.ts"
 }
@@ -1809,10 +1812,11 @@ GbtAIBjIcV0at19ACAp7T3phz6_co1m3butnzxknJddz3svNQnkkQ
 
         <figure><artwork><![CDATA[
 eyJhbGciOiJFUzI1NiIsImtpZCI6IlA1VXBPdjBlTXExd2N4TGY3V3hJZzA5SmRTWU
-dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiZXhwI
-joxNDc0MjQzNTMwLCJjZG5pdWMiOiJyZWdleDpodHRwOi8vY2RuaVxcLmV4YW1wbGU
-vZm9vL2Jhci9bMC05XXszfVxcLnRzIn0.APth9x43OjTReLxPskceE0MrcO62lKhwI
-Gd7YL6YK3FJiZF8-UXnUIGZIAebLe7R0FwZQv37VUoicEPmqBpaYg
+dZRkRPV2tsZHVlYUltZjAifQ.eyJjZG5pZXRzIjozMCwiY2RuaXN0dCI6MSwiY2Rua
+XN0ZCI6MiwiZXhwIjoxNDc0MjQzNTMwLCJjZG5pdWMiOiJyZWdleDpodHRwOi8vY2R
+uaVxcLmV4YW1wbGUvZm9vL2Jhci9bMC05XXszfVxcLnRzIn0.2TQBd2k8szWERK8xw
+1DWO-hqQhLfi0OF4N4aHvpQkbGRNhgloraOIMHDrfNH_YpOpufaeodLPGZCgkoIcGc
+ckg
 ]]></artwork></figure>
       </section>
     </section>

--- a/example/index.js
+++ b/example/index.js
@@ -57,12 +57,14 @@ var samples = {
   "chained-1": {
     "cdniets": 30,
     "cdnistt": 1,
+    "cdnistd": 2,
     "exp": 1474243500,
     "cdniuc": "regex:http://cdni\\.example/foo/bar/[0-9]{3}\\.ts"
   },
   "chained-2": {
     "cdniets": 30,
     "cdnistt": 1,
+    "cdnistd": 2,
     "exp": 1474243530,
     "cdniuc": "regex:http://cdni\\.example/foo/bar/[0-9]{3}\\.ts"
   }


### PR DESCRIPTION
This claim will allow CDNs to determine what path should be used
for cookies and other Signed Token Renewal Transports.

Also, I apparently changed a bunch of tabs to spaces in my editor.