### PR TITLE
Added backslash escape for backslash.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -616,7 +616,7 @@
               <t>
                 <figure>
                   <artwork>
-[^:]*\\://[^/]*/folder/content/quality_[^/]*/segment.{3}\\.mp4(\?.*)?
+[^:]*\\://[^/]*/folder/content/quality_[^/]*/segment.{3}\\.mp4(\\?.*)?
                   </artwork>
                 </figure>
               </t>


### PR DESCRIPTION
This is required because the container is a JSON string.