### PR TITLE
[WIP] Add cdnierr claim.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -621,6 +621,25 @@
           redirection or Signed Token Transport MUST also contain a CDNI Signed Token Depth claim, and the
           value MUST be the same as in the received signed JWT.</t>
         </section>
+        <section anchor="cdnierr_claim" title="CDNI Error Redirect URI (cdnierr) claim">
+          <t>CDNI Error Redirect URI (cdnierr) [optional] - The location to which the client
+          MUST be redirected if the validation of a signed JWT fails for a reason other than
+          presenting an invalid signature. If a well-formed signed JWT would be rejected for
+          a reason other than an invalid signature (that is, a reason that would be logged
+          as code other than 400 or 500 according to <xref target="logging"/>), instead of
+          returning an appropriate error code, the CDN must return HTTP Code 303 with a
+          Location parameter that redirects the client to the CDNI Error Redirect URI, unless
+          the CDNI Error Redirect Code is present, non-zero, and specifies redirection, in
+          which case that value MUST be used for the redirection response. A server MUST NOT
+          redirect a client to the CDNI Error Redirect URI unless that client presents a
+          signed JWT with a valid signature.<t>
+        </section>
+        <section anchor="cdnierc_claim" title="CDNI Error Redirect Code (cdnierc) claim">
+          <t>CDNI Error Redirect Code (cdnierc) [optional] - The HTTP Code to use for redirection
+          if required by the CDNI Error Redirect URI. Its type is a JSON integer. A signed JWT
+          MUST be one of 301, 302, 303, 305, or 307. If this claim is zero or missing, it is
+          treated as though it were 303, as described in <xref target="cdnierr_claim"/>.</t>
+        </section>
         <section anchor="uri_container_forms" title="URI Container Forms">
           <t>The URI Container (cdniuc) claim takes one of the following forms. More forms may be added in the future to extend the capabilities.</t>
           <t>Before utilizing a URI with this container, the following steps MUST be performed:


### PR DESCRIPTION
This isn't quite complete, since it needs an example if we like it and maybe some clarification around the language.

The problem this is trying to solve is that signers want to redirect the user somewhere useful if their token is expired or otherwise not ok. (This "somewhere useful" might ask for additional credentials which can be used to provide a token, present a useful error message to the user, or provide alternate content.)

I'm particularly interested in feedback about whether it's necessary to allow redirects other than 303. I suspect some implementations will need 302 for legacy devices, but the ambiguity makes 303 much better for modern devices. Likewise, I think 307 will be desirable whenever the CDN uses methods other than GET, which aren't necessarily common, but do exist. And as long as we're supporting 302, 303, and 307, there's no reason not to allow any of the redirect codes that use Location for the redirect.