### PR TITLE
Clarify parsing requirements for JWS location.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -391,7 +391,7 @@
         <t>a reserved character (as defined in <xref target="RFC3986"/> Section 2.2),</t>
         <t>the URI Signing Package Attribute name,</t>
         <t>if the last character of the URI Signing Package Attribute name is not a reserved character, an equal symbol ('='),</t>
-        <t>and a sequence of non-reserved characters that will be interpreted as a signed JWT,</t>
+        <t>and a sequence of zero or more non-reserved characters that will be interpreted as a signed JWT,</t>
         <t>terminated by either a reserved character or the end of the URI.</t>
      </list>
      The first such match will be taken to provide the signed JWT; the URI will not be searched


### PR DESCRIPTION
I think this is just editorial, but might represent a divergence of views. It's a corner case, but an important one to nail down, since the first one is taken. Consider this URI:

http://example.com/URISigningPackage=/URISigningPackage=ACTUAL.JWS.SIGNEDPROPERLY/path/to/content.m3u8

If zero-length is allowed, that URI will come back 403 because a zero-length JWS isn't valid. Otherwise, the real token will be found and will come back 200. No one should actually produce URIs like that, but there should be but a single interpretation, I think. And zero-length seems as reasonable of an interpretation as any.