### PR TITLE
Updated figure text.

### DIFF
--- a/draft-ietf-cdni-uri-signing.xml
+++ b/draft-ietf-cdni-uri-signing.xml
@@ -200,7 +200,7 @@
         the content (#4).</t>
 
         <figure anchor="fig_single_cdn"
-                title="Figure 1: URI Signing in a CDN Environment">
+                title="URI Signing in a CDN Environment">
           <artwork>
                 --------
                /        \
@@ -238,7 +238,7 @@
         dCDN before delivering the content (#6). Note: The CDNI call flows are covered in <xref
         target="operation">Detailed URI Signing Operation</xref>.</t>
 
-        <figure title="Figure 2: URI Signing in a CDNI Environment">
+        <figure anchor="fig_cdni_env" title="URI Signing in a CDNI Environment">
           <artwork>
                                    +-------------------------+
                                    |Request Redirection Modes|
@@ -941,7 +941,7 @@
         (assuming HTTP redirection, iterative request routing, and a CDN
         path with two CDNs) includes the following steps:</t>
 
-        <figure title="Figure 4: HTTP-based Request Routing with URI Signing">
+        <figure anchor="fig_http_routing" title="HTTP-based Request Routing with URI Signing">
           <artwork>
      End-User           dCDN                 uCDN                 CSP
      |                    |                    |                    |
@@ -1075,7 +1075,7 @@
         (assuming iterative DNS request routing and a CDN path with two
         CDNs) includes the following steps.</t>
 
-        <figure title="Figure 5: DNS-based Request Routing with URI Signing">
+        <figure anchor="fig_dns_routing" title="DNS-based Request Routing with URI Signing">
           <artwork>
      End-User            dCDN                 uCDN                CSP
      |                    |                    |                    |


### PR DESCRIPTION
The latest drafts have duplicate figure numbers, some of which don't match.
This adds anchors to the figures so they will be automatically numbered and
removes incorrect figure headings.